### PR TITLE
Split migrate from build so CI cannot migrate production

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,5 +42,5 @@ The dev server starts on <http://localhost:3000>.
 To apply migrations locally:
 
 ```bash
-node scripts/migrate.mjs
+npm run migrate
 ```

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "scripts": {
     "dev": "vite dev --port 3000",
     "generate-routes": "tsr generate",
-    "build": "node scripts/migrate.mjs && vite build",
+    "build": "vite build",
+    "migrate": "node scripts/migrate.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -229,3 +229,12 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "buildCommand": "npm run build"
+  "buildCommand": "npm run migrate && npm run build"
 }


### PR DESCRIPTION
Resolves #28, on the map #25.

`npm run build` was `node scripts/migrate.mjs && vite build` — building and migrating were the same act. Safe in CI only by accident: `DATABASE_URL_UNPOOLED` is unset there, so the runner exits 0. Adding that secret to Actions would have made every PR migrate production.

**The split**

| | before | after |
|---|---|---|
| `npm run build` | `node scripts/migrate.mjs && vite build` | `vite build` |
| `npm run migrate` | — | `node scripts/migrate.mjs` |
| `vercel.json` `buildCommand` | `npm run build` | `npm run migrate && npm run build` |

Safety no longer rests on an env var being absent: it rests on CI never invoking `npm run migrate`. That is what unblocks #29 (add build to the CI checks).

**Verified locally**

- `npm run build` with no database in the environment: succeeds, emits `.output/` (the correct Nitro shape), and prints no migration output at all — migrate genuinely does not run.
- `npm run migrate` alone: reaches the runner, reports `DATABASE_URL_UNPOOLED is not set — skipping migrations`.
- `npm run migrate && npm run build` (what Vercel will run): both steps execute in order, migrations first.
- `npm run typecheck` clean; `npm test` 14/14 passing.

A real Vercel deploy is the one thing not exercised here — the chained command is proven, the deploy itself is not.

**One extra file**

`src/routeTree.gen.ts` is committed regenerated. The checked-in copy was stale, and any build rewrites it; left alone it would dirty the tree the moment #29 puts a build in CI.

**Noted, not fixed:** `scripts/migrate.mjs` still exits 0 silently when `DATABASE_URL_UNPOOLED` is unset. Now that migrate is a standalone deploy step, a missing env var on Vercel means a deploy ships without its migrations and says nothing. Logged as fog on the map rather than decided here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018Jm3f6FLbLBYprvLKpb2Yd
