### PR TITLE
Add a build job to CI, and assert it produced a Nitro bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,15 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
+          # Node 22.12 matches package.json's `engines` and the runtime Vercel
+          # serves, so CI compiles against the version production runs.
           node-version: "22.12"
           cache: "npm"
+      # Node 22.12 ships npm 10, which rejects this lockfile: it demands an
+      # entry for `lru-cache@11.5.2`, an *optional peer* of nitro's unstorage
+      # that npm 11 legitimately declines to lock. The lockfile is written by
+      # npm 11; give CI the same npm rather than downgrade the lockfile.
+      - run: npm i -g npm@11
       - run: npm ci
       - run: npm run typecheck
       - run: npm test
@@ -25,6 +32,7 @@ jobs:
         with:
           node-version: "22.12"
           cache: "npm"
+      - run: npm i -g npm@11
       - run: npm ci
       # No database in reach: `npm run build` is `vite build` alone, and the
       # migration step lives in `npm run migrate`, which CI never invokes.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,32 @@ jobs:
       - run: npm ci
       - run: npm run typecheck
       - run: npm test
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.12"
+          cache: "npm"
+      - run: npm ci
+      # No database in reach: `npm run build` is `vite build` alone, and the
+      # migration step lives in `npm run migrate`, which CI never invokes.
+      - run: npm run build
+      # `vite build` exits 0 even when the Nitro plugin is missing from
+      # vite.config.ts -- it just emits a plain `dist/` SPA instead of the
+      # `.output/` server bundle Vercel needs. That is exactly how three
+      # broken deploys shipped green. The build alone does not catch it;
+      # asserting the output shape does.
+      - name: Verify the build produced a Nitro server bundle
+        run: |
+          for artifact in .output/nitro.json .output/server/index.mjs; do
+            if [ ! -f "$artifact" ]; then
+              echo "::error::Missing $artifact -- the build did not produce a Nitro server bundle."
+              echo "Check that vite.config.ts still registers the nitro() plugin."
+              ls -la dist .output 2>/dev/null || true
+              exit 1
+            fi
+          done
+          echo "Nitro server bundle present: $(cat .output/nitro.json)"


### PR DESCRIPTION
Part of #25. Closes #29.

CI ran `typecheck` and `test` but never compiled. That gap shipped three broken deploys whose build produced the wrong output shape (`dist/` instead of `.output/`, from a missing Nitro vite plugin).

## What changed

A second job, `build`, running in parallel with `test`:

1. `npm run build`
2. a step asserting the build produced a Nitro server bundle (`.output/nitro.json` and `.output/server/index.mjs`).

## Why the assertion, and not just the build

The ticket assumed a real build catches the incident. It does not. Verified locally by deleting `nitro()` from `vite.config.ts`:

```
build exit=0     # and emits dist/, not .output/
```

`vite build` is perfectly happy to produce a plain SPA. A CI build step alone would have been **green for all three broken deploys**. The output-shape assertion is the part that actually fails:

```
::error::Missing .output/nitro.json -- the build did not produce a Nitro server bundle.
verify exit=1
```

## Choices worth naming

- **Separate `build` job, not a step on `test`.** #30 has to name required status checks; two named checks mean a red one says whether it was the tests or the compile. Parallel, so no wall-clock cost beyond a second `npm ci` (npm cache is warm).
- **No `paths:` filter.** Per the constraint on #29: a `skipped` required check *passes* branch protection, so a path-filtered build would silently un-gate any PR whose paths don't match.
- **No database in reach.** Since the migrate/build split (#28), `npm run build` is `vite build` alone and CI never invokes `npm run migrate`. Verified: a build with no `DATABASE_URL*` in the environment succeeds and prints no migration output.

## Verified locally

`npm run typecheck` clean · `npm test` 14/14 · `npm run build` emits `.output/` · working tree clean after a build (no `routeTree.gen.ts` churn) · `ci.yml` parses as YAML.

The real proof is this PR's own checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01U6Z53Bes7ayWHVcpoQWRPy
