### PR TITLE
Document the fork-PR secrets invariant in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,19 @@
 name: CI
+
+# INVARIANT: this workflow must never expose secrets to fork pull requests.
+# The repo is public, so anyone can open a PR from a fork and the code in that
+# PR runs here. Two things keep that safe, and both are easy to undo by accident:
+#
+#   1. The trigger is `pull_request`, NOT `pull_request_target`. Fork code runs
+#      with a read-only GITHUB_TOKEN and no access to repository secrets.
+#      `pull_request_target` runs in the base repo's context with secrets in
+#      reach - do not switch to it, even to get a token that can post comments.
+#   2. No step references `secrets.*` or reaches a database. `npm run migrate`
+#      lives only in the Vercel build command, never here (see issue #28).
+#
+# Adding a deploy step, a secret, or a `pull_request_target` trigger breaks the
+# invariant silently - nothing will fail to tell you. See issue #40.
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Part of #40.

The repo went public in #39, so pull requests from forks are now possible for the first time. `ci.yml` is safe against them today, but only incidentally:

- the trigger is `pull_request`, not `pull_request_target`, so fork code gets a read-only `GITHUB_TOKEN` and no repository secrets;
- no step references `secrets.*` or reaches a database — `npm run migrate` lives only in the Vercel build command since #28.

Both properties are one careless edit away from gone, and nothing would fail to announce it. #29 is about to add `npm run build` to this same file, so the person most likely to break the invariant is reading `ci.yml`, not `docs/adr/`. This writes the rule where it will be read.

Comment-only change. Verified by parsing the workflow before and after: triggers (`push`, `pull_request`) and the five steps are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LxFpZGNLpukHL1LQwUzu7H