### PR TITLE
DO NOT MERGE: proof that CI catches a missing Nitro plugin

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,13 @@
 import { defineConfig } from 'vite'
 
 import { tanstackStart } from '@tanstack/react-start/plugin/vite'
-import { nitro } from 'nitro/vite'
+
 
 import viteReact from '@vitejs/plugin-react'
 
 const config = defineConfig({
   resolve: { tsconfigPaths: true },
-  plugins: [tanstackStart(), nitro(), viteReact()],
+  plugins: [tanstackStart(), viteReact()],
 })
 
 export default config


### PR DESCRIPTION
Throwaway. Removes `nitro()` from vite.config.ts to prove the new `build` job on #41 goes red. Expect: `npm run build` exits 0, the output-shape step fails. Closing unmerged as soon as the check reports.