### PR TITLE
PROOF ONLY — do not merge: red required check must block main

### DIFF
--- a/src/__tests__/branch-protection-proof.test.ts
+++ b/src/__tests__/branch-protection-proof.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from "vitest";
+
+// Temporary: proves the required `test` status check blocks a merge.
+// Delete along with the PR that carries it (wayfinder #30).
+describe("branch protection proof", () => {
+  it("fails on purpose", () => {
+    expect(1).toBe(2);
+  });
+});


### PR DESCRIPTION
Temporary proof for #30. **Do not merge — close this PR once observed.**

Carries a deliberately failing vitest so the required `test` status check goes red.
Confirms branch protection on `main` refuses the merge and production does not move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vb4MmDP95WmWCqYsXFZU9F