### PR TITLE
Stop building preview deployments for non-main branches

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,10 @@
 {
-  "buildCommand": "npm run migrate && npm run build"
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "buildCommand": "npm run migrate && npm run build",
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "**": false
+    }
+  }
 }


### PR DESCRIPTION
Resolves #48.

Preview deployments have no role in this project's workflow — preview is the local dev server, production is Vercel, and there is no intermediate stage. Meanwhile every branch push triggered a Vercel build, and `buildCommand` runs `npm run migrate`, so a throwaway branch's DDL ran against whatever database the preview could reach.

#48 offered three candidates (no database, a shared Neon dev branch, a Neon branch per preview) that all argue over *what previews connect to*. Since previews aren't used, the answer is to stop building them.

```json
"git": { "deploymentEnabled": { "main": true, "**": false } }
```

Two details, both from [Git Configuration](https://vercel.com/docs/project-configuration/git-configuration):

- **`main` still deploys.** Vercel's rule: *"If a branch matches multiple rules and at least one rule is `true`, a deployment will occur."* The bare `"deploymentEnabled": false` form would have killed production deploys too.
- **`**` rather than `*`.** minimatch's `*` does not match across `/`, and this repo has slash-bearing branches (`research/vercel-ci-gate`) that a bare `*` would have left deploying.

### What this does not cover

Fork pull requests. A fork PR's build reads the *fork's* `vercel.json`, so a fork that deletes this block still gets a preview once someone clicks authorize. That residual risk is now tracked as its own ticket rather than left implicit.

### Trade-off accepted

PRs no longer carry a preview URL. CI (typecheck, test, build) is the only automated signal on a branch, which matches how the work is actually reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019rmHYNViAHxEQWPYeXZmR4