### PR TITLE
Fail the build when migrations cannot run

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,18 @@
 
 A self-hosted weekly meal planner for one household.
 
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Flfeq%2Ffood-organizer&stores=%5B%7B%22type%22%3A%22neon%22%7D%5D)
+<!--
+  The `products` parameter provisions the Neon database as part of the clone
+  wizard, so `DATABASE_URL_UNPOOLED` exists before the first build runs. This
+  matters more than it looks: `npm run migrate` now fails the build when that
+  variable is missing (see scripts/migrate.mjs), so a button that does not
+  provision a database produces a red first deploy rather than a green one.
+
+  Keep the full integration shape -- `{"type":"neon"}` is not a form Vercel
+  recognises, and a malformed value is ignored silently rather than rejected.
+-->
+
+[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Flfeq%2Ffood-organizer&project-name=food-organizer&repository-name=food-organizer&products=%5B%7B%22type%22%3A%22integration%22%2C%22integrationSlug%22%3A%22neon%22%2C%22productSlug%22%3A%22neon%22%2C%22protocol%22%3A%22storage%22%7D%5D)
 
 ## Before you deploy
 
@@ -23,7 +34,9 @@ A self-hosted weekly meal planner for one household.
 2. Vercel will clone this repo into your account and create the project.
 3. When prompted, add the **Neon** database from Vercel Storage (Free plan).
    The integration injects `DATABASE_URL` and `DATABASE_URL_UNPOOLED`
-   automatically — do not copy connection strings manually.
+   automatically — do not copy connection strings manually. **Do not skip this
+   step**: the build applies the database schema, so without it the deploy
+   fails rather than shipping an app with no database.
 4. Click **Deploy**. The database schema is applied as a build step.
 5. Open the deployed URL and complete the first-run setup: create the admin
    account, confirm the week start, and seed the catalogue.

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -3,6 +3,13 @@
  * Migration runner. Connects on DATABASE_URL_UNPOOLED (direct Neon connection
  * required for DDL) and applies any pending migrations from /migrations.
  * Runs as a build step before vite build.
+ *
+ * This script must NEVER exit 0 without having looked at the database.
+ * `vercel.json` runs `npm run migrate && npm run build`, so a soft exit here
+ * ships a green deploy whose schema is stale -- the quietest possible way for
+ * a broken deploy to reach production. Every path below either applies the
+ * pending migrations or exits non-zero. See
+ * https://github.com/lfeq/food-organizer/issues/52
  */
 import pg from "pg"
 import { readdir, readFile } from "fs/promises"
@@ -11,14 +18,64 @@ import { fileURLToPath } from "url"
 
 const __dirname = dirname(fileURLToPath(import.meta.url))
 
-const url = process.env.DATABASE_URL_UNPOOLED
+/** Fail before opening a connection: a misconfiguration should not need a
+ *  database in reach to announce itself. */
+function fail(message) {
+  console.error(`Migration failed: ${message}`)
+  process.exit(1)
+}
+
+// An empty string is a misconfiguration, not an absence -- a trailing `=` in a
+// dashboard field lands here, and treating it as "no database" would restore
+// the silent skip through the back door.
+const url = process.env.DATABASE_URL_UNPOOLED?.trim()
 if (!url) {
-  console.error("DATABASE_URL_UNPOOLED is not set — skipping migrations")
-  process.exit(0)
+  if (process.env.DATABASE_URL?.trim()) {
+    // The pooled URL is present and the direct one is not. Pointing pg at the
+    // pooler instead would fail partway through some later DDL statement, so
+    // stop here and name the likely cause.
+    fail(
+      "DATABASE_URL is set but DATABASE_URL_UNPOOLED is not.\n" +
+        "  Migrations need the direct (unpooled) connection: the pooler cannot run DDL.\n" +
+        "  On Vercel this usually means the variable is scoped to the wrong environment.\n" +
+        "  Check Settings -> Environment Variables and confirm DATABASE_URL_UNPOOLED\n" +
+        "  is available to Production builds."
+    )
+  }
+  fail(
+    "DATABASE_URL_UNPOOLED is not set.\n" +
+      "  This app cannot run without a database, so the build stops here rather\n" +
+      "  than deploying green with an unmigrated schema.\n" +
+      "  On Vercel: add the Neon integration (Storage -> Neon), which injects\n" +
+      "  DATABASE_URL and DATABASE_URL_UNPOOLED for you.\n" +
+      "  Locally: copy .env.example to .env.local and fill both in."
+  )
+}
+
+const migrationsDir = join(__dirname, "..", "migrations")
+
+let files
+try {
+  files = (await readdir(migrationsDir)).filter((f) => f.endsWith(".sql")).sort()
+} catch (err) {
+  fail(`could not read ${migrationsDir}: ${err.message}`)
+}
+
+// This repo ships its migrations in-tree, so zero of them means a broken
+// checkout, not a fresh project. Applying nothing would look identical to
+// being up to date.
+if (files.length === 0) {
+  fail(
+    `no .sql files found in ${migrationsDir}.\n` +
+      "  This repo commits its migrations, so an empty directory means the\n" +
+      "  checkout is incomplete rather than that there is nothing to apply."
+  )
 }
 
 const client = new pg.Client({ connectionString: url })
 await client.connect()
+
+let applied = 0
 
 try {
   await client.query(`
@@ -28,11 +85,6 @@ try {
       applied_at  timestamptz NOT NULL DEFAULT now()
     )
   `)
-
-  const migrationsDir = join(__dirname, "..", "migrations")
-  const files = (await readdir(migrationsDir))
-    .filter((f) => f.endsWith(".sql"))
-    .sort()
 
   for (const file of files) {
     const { rows } = await client.query(
@@ -48,6 +100,7 @@ try {
       await client.query("INSERT INTO _migrations (name) VALUES ($1)", [file])
       await client.query("COMMIT")
       console.log(`Applied: ${file}`)
+      applied++
     } catch (err) {
       await client.query("ROLLBACK")
       throw err
@@ -56,3 +109,10 @@ try {
 } finally {
   await client.end()
 }
+
+// Always say what happened. A silent success cannot be told apart from a run
+// that never looked, which is the failure mode this script exists to prevent.
+console.log(
+  `Migrations up to date: ${applied} applied, ${files.length - applied} already present ` +
+    `(latest ${files[files.length - 1]}).`
+)


### PR DESCRIPTION
Resolves the decision in #52 and lands it. Part of #25.

## The hole

`scripts/migrate.mjs` exited **0** when `DATABASE_URL_UNPOOLED` was unset. Since #28 split migrate out of build, `vercel.json` runs `npm run migrate && npm run build` — so a missing or mis-scoped variable meant **production compiled and deployed green with pending migrations unapplied**. The map's destination hit by the quietest possible route.

The skip was never a decision. `git log` puts it in the walking-skeleton commit (#14) alongside the runner itself — scaffolding convenience. And #48 removed the only scenario that could have justified it: with preview deployments off, every build that runs migrate is production or local, so "no credentials" can only mean a real misconfiguration.

## What changed in the runner

Validation now happens **before** the connection opens, so a misconfiguration doesn't need a database in reach to announce itself:

| Condition | Before | After |
|---|---|---|
| `DATABASE_URL_UNPOOLED` unset | exit 0, silent | exit 1 |
| set to `""` or whitespace | exit 0, silent | exit 1 |
| `DATABASE_URL` set, `_UNPOOLED` missing | exit 0, silent | exit 1, distinct message naming env mis-scoping |
| `migrations/` empty | exit 0, indistinguishable from up-to-date | exit 1 |
| `migrations/` missing/unreadable | crash mid-run | exit 1, named |
| success | silent | logs applied/pending counts |

The empty-string case matters more than it looks: a trailing `=` in a dashboard field lands there, and treating it as "no database" would restore the silent skip through the back door. The success log matters because a silent green run couldn't be told apart from one that never looked — the exact failure mode this script now exists to prevent.

Connection and SQL errors were already loud (top-level `await` throws, Node exits 1) and are untouched. Deliberately **not** added: sniffing the hostname to detect a pooled URL — that's a guess about Neon's URL format that will rot.

## Why the README button ships with it, not after it

Failing unconditionally turns a forker's first build red, which collides with the map's standing constraint that the one-click Deploy story keeps working. Checking that constraint turned up something worse.

The button was passing `stores=[{"type":"neon"}]`. Vercel documents exactly two `type` values — `"blob"` and `"integration"` — and `"neon"` is neither; Vercel's own Neon template uses `products=` with the full integration shape. **A malformed value is ignored silently rather than rejected**, so the button most likely provisioned no database at all. The forker's deploy went *green* and broke at first page load instead of at build.

That's the same silent-failure class as the bug this PR fixes, just pointed at the forker. The silent skip wasn't protecting fork onboarding — it was concealing that fork onboarding was already broken. So the URL now carries the full integration shape, provisioning Neon inside the clone wizard *before* the first build, and step 3 of **Deploying** says outright that skipping the database now fails the deploy.

Rejected: adding `DATABASE_URL_UNPOOLED` to an `env=` list. Vercel's docs warn against hand-typing credentials, and it would collide with the integration that is supposed to inject them.

## Also rejected: gating on `VERCEL_ENV`

`VERCEL_ENV === "production"` would have protected this instance without touching forks, but it's only exposed when the project's *"Enable access to System Environment Variables"* setting is on. A guard that goes quiet when someone flips a dashboard toggle is the failure mode we're removing, not a fix for it.

## Verification

All five failure paths exercised locally, each exiting 1 with its intended message. `npm run typecheck` clean; `npm test` 14/14.

**Not verified, and it needs a human:** that the new button URL actually provisions Neon. It can only be confirmed by clicking it, which I can't do — tracked as a follow-up ticket on #25. Until that click happens, this PR makes a fork's first deploy red if the URL is still wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GJ6EamNjA2TPCSnG2rUChv
