### PR TITLE
Record the no-credentials-in-preview policy in migrate.mjs

### DIFF
--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -10,6 +10,26 @@
  * a broken deploy to reach production. Every path below either applies the
  * pending migrations or exits non-zero. See
  * https://github.com/lfeq/food-organizer/issues/52
+ *
+ * A companion policy, recorded here because there is nowhere better: NO PREVIEW
+ * BUILD HAS DATABASE CREDENTIALS, BY DESIGN. Vercel offers no way to stop a
+ * fork pull request from deploying (only an authorization gate), so the target
+ * was removed instead of the trigger -- Preview is off in the Neon
+ * integration's environment scope, leaving `DATABASE_URL` and
+ * `DATABASE_URL_UNPOOLED` on Production only. An authorized fork PR build
+ * therefore dies right here, in this script, and that red is the intended
+ * outcome, not a bug to fix. Do not add a VERCEL_ENV skip to "fix" it, and do
+ * not enable Neon preview branching: a copy-on-write branch is still a full
+ * copy of production rows handed to a stranger's build.
+ * See https://github.com/lfeq/food-organizer/issues/56
+ *
+ * That scope lives in the Neon integration's Deployments Configuration in the
+ * Vercel dashboard -- not in `vercel.json` (JSON, which cannot carry this
+ * comment) and not in the variable editor (the integration is Vercel-Managed,
+ * so the scope is locked there). Nothing asserts it: a check would need a
+ * VERCEL_TOKEN, and `ci.yml` may never hold a secret. It is prose because it is
+ * unassertable, which is also why it drifts -- if you are here because it
+ * drifted, see https://github.com/lfeq/food-organizer/issues/57
  */
 import pg from "pg"
 import { readdir, readFile } from "fs/promises"

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -23,13 +23,39 @@
  * copy of production rows handed to a stranger's build.
  * See https://github.com/lfeq/food-organizer/issues/56
  *
- * That scope lives in the Neon integration's Deployments Configuration in the
- * Vercel dashboard -- not in `vercel.json` (JSON, which cannot carry this
- * comment) and not in the variable editor (the integration is Vercel-Managed,
- * so the scope is locked there). Nothing asserts it: a check would need a
- * VERCEL_TOKEN, and `ci.yml` may never hold a secret. It is prose because it is
- * unassertable, which is also why it drifts -- if you are here because it
- * drifted, see https://github.com/lfeq/food-organizer/issues/57
+ * That scope lives in the Vercel dashboard, in TWO places that must agree --
+ * not in `vercel.json`, which is JSON and cannot carry this comment. Both were
+ * set by hand; if you are auditing, check both:
+ *
+ *   1. Storage -> neon-bronze-mirror -> Settings -> "Secure This Resource" ->
+ *      Allowed Environments = "Production environment only". (It is NOT under
+ *      "Advanced Options"; that name appears in older notes and does not
+ *      exist.) Reverting this needs owner permission, so it does not drift by
+ *      casual click.
+ *   2. Project Settings -> Environment Variables: `DATABASE_URL` and
+ *      `DATABASE_URL_UNPOOLED` must read "Production", not "Production and
+ *      Preview".
+ *
+ * Step 2 is NOT implied by step 1, and that is the trap. Restricting the store
+ * re-injects the integration's variables under a fresh `STORAGE_*` prefix as
+ * Sensitive/Production, and LEAVES THE PRE-EXISTING `DATABASE_URL` PAIR BEHIND,
+ * still scoped to Production and Preview, still holding live credentials. The
+ * click alone looks done and is not. Re-scoping those two by hand is what
+ * finished the job -- and they were editable, contrary to the older note that
+ * integration-managed variables are locked (they unlock once the store is
+ * Production-only).
+ *
+ * Consequently this script and the app read `DATABASE_URL*`, while the
+ * integration now maintains the parallel `STORAGE_*` set. Rotating secrets in
+ * the Neon store would refresh `STORAGE_*` and NOT the pair production
+ * actually reads -- so rotation is a production outage waiting to happen until
+ * that divergence is resolved. See
+ * https://github.com/lfeq/food-organizer/issues/66
+ *
+ * Nothing asserts any of this: a check would need a VERCEL_TOKEN, and `ci.yml`
+ * may never hold a secret. It is prose because it is unassertable, which is
+ * also why it drifts -- if you are here because it drifted, see
+ * https://github.com/lfeq/food-organizer/issues/57
  */
 import pg from "pg"
 import { readdir, readFile } from "fs/promises"


### PR DESCRIPTION
Step 4 of [Remove Preview from the Neon integration's environment scope](https://github.com/lfeq/food-organizer/issues/57) — the code half of the ticket. The dashboard half (Preview off in the Neon integration's Deployments Configuration) is a click only the maintainer can make and is tracked on the issue.

[#56](https://github.com/lfeq/food-organizer/issues/56) decided fork previews are kept off the production database by removing the *target*, not the trigger: no preview build gets database credentials at all. That fact has no assertable home — `vercel.json` is JSON and cannot carry a comment, the variable editor locks the scope (the Neon integration is Vercel-Managed), and a CI check would need a `VERCEL_TOKEN` that `ci.yml` may never hold ([#40](https://github.com/lfeq/food-organizer/issues/40)). So it goes in the header of the script that a violated policy actually fails in, in the style of the invariant [#54](https://github.com/lfeq/food-organizer/pull/54) put there and [#42](https://github.com/lfeq/food-organizer/pull/42) put in `ci.yml`.

The note records three things a future reader needs: that a red fork build is the intended outcome rather than a bug, that a `VERCEL_ENV` skip must not be reintroduced to "fix" it, and that Neon preview branching is not the fix either (a copy-on-write branch is still a full copy of production rows).

Comment-only; no behaviour change. `npm run typecheck` clean, 14/14 tests pass.

Refs #57, #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XKpaB5QNcNTeECDwVWpqRM