### PR TITLE
Prove migrations against a disposable database in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,8 +8,15 @@ name: CI
 #      with a read-only GITHUB_TOKEN and no access to repository secrets.
 #      `pull_request_target` runs in the base repo's context with secrets in
 #      reach - do not switch to it, even to get a token that can post comments.
-#   2. No step references `secrets.*` or reaches a database. `npm run migrate`
-#      lives only in the Vercel build command, never here (see issue #28).
+#   2. No step references `secrets.*`, and no step reaches a database that
+#      outlives its own job. The `migrations` job below DOES run
+#      `npm run migrate`, against a throwaway Postgres `services:` container
+#      created and destroyed inside the runner. Its password is a literal in
+#      this file, not a `secrets.*` reference, and nothing outside the runner
+#      can be reached with it. The rule is "no production database, no
+#      secrets", and that job satisfies it: point DATABASE_URL_UNPOOLED at
+#      anything but that container and it does not. `npm run build` still
+#      never migrates -- migrate and build stay separate (see issue #28).
 #
 # Adding a deploy step, a secret, or a `pull_request_target` trigger breaks the
 # invariant silently - nothing will fail to tell you. See issue #40.
@@ -49,8 +56,10 @@ jobs:
           cache: "npm"
       - run: npm i -g npm@11
       - run: npm ci
-      # No database in reach: `npm run build` is `vite build` alone, and the
-      # migration step lives in `npm run migrate`, which CI never invokes.
+      # No database in reach: `npm run build` is `vite build` alone. The
+      # migration step is `npm run migrate` and it belongs to the `migrations`
+      # job, never to this one -- re-welding them would cost CI its build
+      # check (see issue #28).
       - run: npm run build
       # `vite build` exits 0 even when the Nitro plugin is missing from
       # vite.config.ts -- it just emits a plain `dist/` SPA instead of the
@@ -68,3 +77,81 @@ jobs:
             fi
           done
           echo "Nitro server bundle present: $(cat .output/nitro.json)"
+
+  # No `migrations/*.sql` in this repo had ever run before production: until
+  # this job existed, `npm run migrate` lived only in `vercel.json`'s
+  # buildCommand, so the production deploy was the FIRST execution of every
+  # migration ever written. A typo in 0004_*.sql was discovered by a red
+  # production deploy. This job applies the whole set from scratch against a
+  # disposable database, so the SQL is proven before merge. See issue #58.
+  migrations:
+    runs-on: ubuntu-latest
+
+    services:
+      # Throwaway Postgres, born and destroyed with this job. The password is
+      # a literal here on purpose: `services:` credentials must not come from
+      # `secrets.*`, and fork code already runs arbitrary JavaScript in this
+      # runner, so an empty database inside that same runner adds no reach.
+      #
+      # Pin the major version to whatever Neon serves production. Drifting
+      # apart is the one way this job goes green while the deploy it is
+      # protecting fails: a migration that only 17 accepts would pass here and
+      # break there, and nothing would say so.
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: ci-throwaway-not-a-secret
+          POSTGRES_DB: food_organizer_ci
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 20
+
+    env:
+      # `scripts/migrate.mjs` connects on DATABASE_URL_UNPOOLED and, since
+      # issue #52, exits non-zero when it is unset -- so this job must set it.
+      DATABASE_URL_UNPOOLED: postgresql://postgres:ci-throwaway-not-a-secret@localhost:5432/food_organizer_ci
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22.12"
+          cache: "npm"
+      - run: npm i -g npm@11
+      - run: npm ci
+
+      # Run 1: an empty database, so every migration must apply. Asserting the
+      # count rather than just the exit code is what makes the check real --
+      # `migrate.mjs` exits 0 both when it applied everything and when it
+      # applied nothing, and the second of those is the failure being hunted.
+      - name: Apply every migration to an empty database
+        run: |
+          set -euo pipefail
+          expected=$(ls migrations/*.sql | wc -l | tr -d ' ')
+          output=$(npm run migrate)
+          echo "$output"
+          if ! grep -q "Migrations up to date: $expected applied," <<<"$output"; then
+            echo "::error::Expected all $expected migrations to apply to an empty database."
+            exit 1
+          fi
+
+      # Run 2: the same command against the database run 1 just built. This is
+      # the `_migrations` bookkeeping production relies on to not re-run DDL
+      # over live tables -- untested until now. A second run must be a no-op;
+      # if it re-applies anything, the CREATE statements themselves would
+      # error, and if it silently skipped files it would look identical to
+      # being up to date.
+      - name: Prove a second run applies nothing
+        run: |
+          set -euo pipefail
+          expected=$(ls migrations/*.sql | wc -l | tr -d ' ')
+          output=$(npm run migrate)
+          echo "$output"
+          if ! grep -q "Migrations up to date: 0 applied, $expected already present" <<<"$output"; then
+            echo "::error::Migrations are not idempotent -- a second run was not a no-op."
+            exit 1
+          fi


### PR DESCRIPTION
Resolves [Prove migrations against a disposable database in CI](https://github.com/lfeq/food-organizer/issues/58), a ticket on [Map: A broken deploy cannot reach production](https://github.com/lfeq/food-organizer/issues/25).

## The gap

No `migrations/*.sql` in this repo has ever run before production. `npm run migrate` lives only in `vercel.json`'s `buildCommand` (#28 deliberately kept it out of CI), and with preview deployments off (#48) the production build is the **first** execution of any migration. `0001_initial.sql`, `0002_auth.sql` and `0003_accounts.sql` were all first applied against production data. A typo in a future `0004_*.sql` gets discovered by a red production deploy.

## The change

A third, independent `migrations` job. It applies the whole set from scratch against a throwaway `postgres:17` `services:` container, then runs `npm run migrate` a **second** time to prove the `_migrations` bookkeeping makes it a no-op — the bookkeeping production relies on to not re-run DDL over live tables, itself never tested until now.

Both steps assert the **applied/pending counts**, not just the exit code. `migrate.mjs` exits 0 both when it applied everything and when it applied nothing, and the second of those is exactly the failure being hunted.

## Verified locally, not just written

Run against a real `postgres:17` container before pushing:

- **Run 1** on an empty database: `Applied: 0001_initial.sql / 0002_auth.sql / 0003_accounts.sql`, then `Migrations up to date: 3 applied, 0 already present`. Stock Postgres 17 handles everything the SQL needs — the `citext` extension and `settings`' `NOW() AT TIME ZONE timezone` CHECK included.
- **Run 2**: `Migrations up to date: 0 applied, 3 already present`. Idempotent.
- **Negative case**, so the check isn't theatre: a temporary `0004` containing `CREATE TABEL` against a fresh database exited **1** with `syntax error at or near "TABEL"`. The job goes red on bad SQL before merge, which is the entire point. The temp file was removed and is not in this branch.

## Fork safety — the header comment is rewritten, not deleted

`ci.yml`'s header currently claims *"No step references `secrets.*` or reaches a database"*, and that becomes false in its letter. It is exactly the comment a future reader consults before adding a step, so point 2 is rewritten rather than removed.

The rule it protects is **"no production database, no secrets"**, and this job satisfies it:

- The container's password is a **literal in the workflow file**, never a `secrets.*` reference.
- The database is created and destroyed inside the runner; nothing outside it is reachable with that credential.
- Fork code already executes arbitrary JavaScript in this runner. Handing it an empty database inside that same runner adds no reach.

The trigger stays `pull_request`, never `pull_request_target`.

## Not re-welding migrate into build

`npm run build` stays `vite build` alone and #29's Nitro-bundle assertion is untouched. #28's prohibition holds — this is a third job, and the `build` job's own comment is updated to say where `npm run migrate` now lives so the two don't drift back together.

## One thing to decide after this merges

Whether `migrations` joins `test` and `build` as a **required status check** on `main`. Recommended yes, but deliberately not done in this PR: #30's rename trap means required checks match **by job name**, so the check should be added only once a real run has reported under the name `migrations`. That run is this PR.

## Watch item

`postgres:17` must track whatever major Neon serves production. Drift is the one way this job goes green while the deploy it protects fails — a migration only 17 accepts would pass here and break there. Called out in a comment on the `services:` block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JR4ZcjmUK2Rpztq4C5EJcM
