### PR TITLE
DO NOT MERGE: prove the migrations check gates main (#61)

### DIFF
--- a/migrations/0004_gate_proof.sql
+++ b/migrations/0004_gate_proof.sql
@@ -1,0 +1,4 @@
+-- THROWAWAY: deliberately broken SQL, used once to prove that the `migrations`
+-- required status check actually blocks a merge (issue #61). Delete this branch
+-- as soon as the PR has reported BLOCKED; it must never reach main.
+CREATE TABEL gate_proof (id integer);


### PR DESCRIPTION
Throwaway probe for #61. Carries a deliberately broken `migrations/0004_gate_proof.sql` (`CREATE TABEL`) so the `migrations` job goes red.

Expected: `mergeStateStatus: BLOCKED`, with `migrations` failing while `test` and `build` pass. Closed and the branch deleted as soon as it has reported. **Never merge this.**