### PR TITLE
Read the integration's STORAGE_* database URLs, falling back to the plain names

### DIFF
--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -45,17 +45,30 @@
  * integration-managed variables are locked (they unlock once the store is
  * Production-only).
  *
- * Consequently this script and the app read `DATABASE_URL*`, while the
- * integration now maintains the parallel `STORAGE_*` set. Rotating secrets in
- * the Neon store would refresh `STORAGE_*` and NOT the pair production
- * actually reads -- so rotation is a production outage waiting to happen until
- * that divergence is resolved. See
+ * That prefix is NOT editable, so the project cannot be made to inject the
+ * plain names again. It does not need to be: this script and the app now read
+ * `STORAGE_DATABASE_URL*` first and fall back to `DATABASE_URL*`. Both
+ * spellings are legitimate and reach the same database by two different
+ * routes, so neither is a leftover to clean up:
+ *
+ *   - `STORAGE_*` is what a store connected through Vercel's marketplace flow
+ *     injects, and it is the set an integration MAINTAINS. Production is here.
+ *     Because the integration owns it, rotating secrets in the Neon store is a
+ *     safe click -- which it was not while the code read a hand-made pair the
+ *     rotation would not touch.
+ *   - The unprefixed pair is what a store provisioned fresh by the README's
+ *     Deploy button injects (verified in #55), and what `.env.local` and the
+ *     `migrations` CI job use. A forker never sees a prefix.
+ *
+ * Prefixed wins so that production runs on the maintained set. See
  * https://github.com/lfeq/food-organizer/issues/66
  *
- * Nothing asserts any of this: a check would need a VERCEL_TOKEN, and `ci.yml`
- * may never hold a secret. It is prose because it is unassertable, which is
- * also why it drifts -- if you are here because it drifted, see
- * https://github.com/lfeq/food-organizer/issues/57
+ * The scope facts above still assert nothing -- checking them needs a
+ * VERCEL_TOKEN and `ci.yml` may never hold a secret, so they are prose, which
+ * is also why they drift. If you are here because they drifted, see
+ * https://github.com/lfeq/food-organizer/issues/57. THIS fact is different:
+ * the variable names are visible from inside the build, so the log line below
+ * names the one it connected on. A deploy that quietly changes route says so.
  */
 import pg from "pg"
 import { readdir, readFile } from "fs/promises"
@@ -71,29 +84,44 @@ function fail(message) {
   process.exit(1)
 }
 
-// An empty string is a misconfiguration, not an absence -- a trailing `=` in a
-// dashboard field lands here, and treating it as "no database" would restore
-// the silent skip through the back door.
-const url = process.env.DATABASE_URL_UNPOOLED?.trim()
+// The same database answers to two spellings; see the header. Selection is by
+// which key is DEFINED, not by which holds a usable value, so that an empty
+// string stays a misconfiguration rather than falling through to the other
+// spelling: a trailing `=` in a dashboard field lands here, and treating it as
+// "no database" would restore the silent skip through the back door.
+function pick(name) {
+  for (const key of [`STORAGE_${name}`, name]) {
+    if (process.env[key] !== undefined) {
+      return { key, value: process.env[key].trim() }
+    }
+  }
+  return undefined
+}
+
+const unpooled = pick("DATABASE_URL_UNPOOLED")
+const url = unpooled?.value
 if (!url) {
-  if (process.env.DATABASE_URL?.trim()) {
+  if (pick("DATABASE_URL")?.value) {
     // The pooled URL is present and the direct one is not. Pointing pg at the
     // pooler instead would fail partway through some later DDL statement, so
     // stop here and name the likely cause.
     fail(
-      "DATABASE_URL is set but DATABASE_URL_UNPOOLED is not.\n" +
+      "A pooled database URL is set but the unpooled one is not.\n" +
         "  Migrations need the direct (unpooled) connection: the pooler cannot run DDL.\n" +
+        "  Looked for STORAGE_DATABASE_URL_UNPOOLED, then DATABASE_URL_UNPOOLED.\n" +
         "  On Vercel this usually means the variable is scoped to the wrong environment.\n" +
-        "  Check Settings -> Environment Variables and confirm DATABASE_URL_UNPOOLED\n" +
+        "  Check Settings -> Environment Variables and confirm the unpooled URL\n" +
         "  is available to Production builds."
     )
   }
   fail(
-    "DATABASE_URL_UNPOOLED is not set.\n" +
+    "No unpooled database URL is set.\n" +
+      "  Looked for STORAGE_DATABASE_URL_UNPOOLED, then DATABASE_URL_UNPOOLED.\n" +
       "  This app cannot run without a database, so the build stops here rather\n" +
       "  than deploying green with an unmigrated schema.\n" +
       "  On Vercel: add the Neon integration (Storage -> Neon), which injects\n" +
-      "  DATABASE_URL and DATABASE_URL_UNPOOLED for you.\n" +
+      "  one of those spellings for you -- which one depends on how the store\n" +
+      "  was connected, and either is fine.\n" +
       "  Locally: copy .env.example to .env.local and fill both in."
   )
 }
@@ -117,6 +145,11 @@ if (files.length === 0) {
       "  checkout is incomplete rather than that there is nothing to apply."
   )
 }
+
+// Name the source, not the value: this is the only part of the two-spelling
+// story that is observable from inside a build, so a silent change of route
+// shows up in the deploy log instead of being discovered by a rotation.
+console.log(`Connecting on ${unpooled.key}`)
 
 const client = new pg.Client({ connectionString: url })
 await client.connect()

--- a/src/runtime.server.ts
+++ b/src/runtime.server.ts
@@ -4,8 +4,17 @@ import { PgClient } from "@effect/sql-pg"
 // Layer.retry at construction is the right level for serverless: each cold Vercel
 // invocation builds the layer fresh. Neon Free's 5-minute scale-to-zero means the
 // first connection after idle errors; the backoff here absorbs that resume latency.
+// Two spellings reach the same database. `STORAGE_DATABASE_URL` is what a
+// store connected through Vercel's marketplace flow injects and is the set an
+// integration maintains, so it wins; `DATABASE_URL` is what a fresh Deploy
+// button provision and `.env.local` give you. Selection is by which key is
+// defined, matching scripts/migrate.mjs, whose header carries the full story.
+// See https://github.com/lfeq/food-organizer/issues/66
+const databaseUrl =
+  process.env["STORAGE_DATABASE_URL"] ?? process.env["DATABASE_URL"] ?? ""
+
 const PgLayer = PgClient.layer({
-  url: Redacted.make(process.env["DATABASE_URL"] ?? ""),
+  url: Redacted.make(databaseUrl),
   connectTimeout: Duration.seconds(30),
 }).pipe(
   Layer.retry(


### PR DESCRIPTION
Resolves [Should the app read the integration's STORAGE_* variables instead of DATABASE_URL?](https://github.com/lfeq/food-organizer/issues/66), on map [A broken deploy cannot reach production](https://github.com/lfeq/food-organizer/issues/25).

## The premise the ticket got wrong

The ticket assumed #57 *orphaned* `DATABASE_URL` / `DATABASE_URL_UNPOOLED` — that the integration had maintained them and then abandoned them under a new prefix. It hadn't. The maintainer created that pair **by hand** at project setup, copying the values out of Neon's own variables. They were never managed. #57 only made that visible by adding a managed set beside them.

This is legible in the variable list: every `STORAGE_*` row carries an integration badge, while `DATABASE_URL` and `DATABASE_URL_UNPOOLED` carry only a lock.

So there was no prior state to restore, only one to choose.

## Why not just make the integration inject the plain names

That was the preferred answer — one managed set, named the same way a forker's project names them — and it is **not reachable**: the store→project connection's environment-variable prefix is not editable. The only remaining route was disconnecting and reconnecting a production store in the hope the connect dialog offers the field, which is an experiment on production to win a cosmetic property.

## What this does instead

`STORAGE_DATABASE_URL*` first, falling back to `DATABASE_URL*`, in both `scripts/migrate.mjs` and `src/runtime.server.ts`.

Two spellings, permanently — but they correspond to two real provisioning paths, not to an accident:

| path | spelling | why |
|---|---|---|
| production | `STORAGE_*` | store connected through Vercel's marketplace flow; **maintained by the integration** |
| a forker (#55) | plain | fresh Deploy-button provision injects unprefixed |
| local dev | plain | `.env.local` from `.env.example` |
| `migrations` CI job (#58) | plain | throwaway `postgres:17` container |

Prefixed wins so production runs on the maintained set. That is the whole point: **rotating secrets in the Neon store is now a safe click**, where before it would have refreshed `STORAGE_*` and left production reading a hand-made pair the rotation never touches.

`README.md`, `.env.example` and `ci.yml` are untouched — the fallback is precisely what keeps those three paths working without edits.

## Two ways this could have gone wrong, and didn't

- **Selection is by which key is `defined`, not by which holds a usable value.** An empty `STORAGE_DATABASE_URL_UNPOOLED` (a trailing `=` in a dashboard field) stays a hard failure instead of falling through to the plain name — falling through would have reopened #52's silent skip from the other side.
- **No fallback on connection failure.** A bad prefixed URL fails; it does not quietly reach a different database.

## Verification

Typecheck, 14/14 tests, and `npm run build` (Nitro bundle) all pass. Against a throwaway `postgres:17` container:

| case | result |
|---|---|
| prefixed only (production's shape) | `Connecting on STORAGE_DATABASE_URL_UNPOOLED`, 3 applied, exit 0 |
| rerun (idempotence) | 0 applied, 3 already present, exit 0 |
| plain only (forker / CI / local) | `Connecting on DATABASE_URL_UNPOOLED`, 3 applied, exit 0 |
| both set, **plain URL deliberately unreachable** | succeeded on the prefixed one — precedence proven negatively |
| **prefixed URL unreachable, plain reachable** | exit 1, no silent fallback |
| neither set | exit 1, message naming both spellings |
| pooled set, unpooled missing | exit 1, message naming both spellings |
| empty prefixed + valid plain | exit 1 — did **not** fall through |

## The header comment

`scripts/migrate.mjs`'s header is **rewritten in place**, not deleted (the #58 precedent). Leaving prose that says "the code reads `DATABASE_URL*` while the integration maintains `STORAGE_*`" would be actively false once this lands. The environment-scope facts around it still assert nothing — they need a `VERCEL_TOKEN` and `ci.yml` may never hold a secret (#40, #56). This fact is different: the variable names are visible from inside the build, so `migrate.mjs` now **logs which one it connected on**. A deploy that quietly changes route says so in the build log instead of being discovered by a rotation.

## After merge

1. Redeploy `main`; the build log should read `Connecting on STORAGE_DATABASE_URL_UNPOOLED`. Since #52 a green build means the script actually reached the database, so that green is the real proof production is on the managed set.
2. Only then delete the hand-made `DATABASE_URL` / `DATABASE_URL_UNPOOLED` from Project Settings → Environment Variables — a cleanup that can no longer break anything.
3. Then click **Rotate Secrets** on `neon-bronze-mirror`.

That ordering matters, and environment variables are baked into a deployment at build time, so the running production deployment is unaffected until step 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KUeFPxTG1NEQpt63DMAmBV
