### PR TITLE
Settle how IBM Plex is loaded, and what shows before it arrives

### DIFF
--- a/docs/design/visual-system.md
+++ b/docs/design/visual-system.md
@@ -161,9 +161,67 @@ IBM Plex Mono  400 500 600
 ```
 
 Fallback stacks: `'IBM Plex Sans', system-ui, sans-serif` and
-`'IBM Plex Mono', ui-monospace, monospace`. **Whether these are served from
-Google Fonts or self-hosted is a separate decision** and does not affect
-anything below.
+`'IBM Plex Mono', ui-monospace, monospace`. Both are used **plain**, with no
+metric tuning. Note that `src/styles.css` today writes bare `monospace`, which
+resolves to a slab serif on some platforms; the value above is the binding one.
+
+How they are served is settled in [Loading the fonts](#loading-the-fonts)
+below, and does not affect the scales.
+
+### Loading the fonts
+
+Self-hosted from Fontsource's pre-built subsets, **vendored** into
+`public/fonts/` under stable filenames with a hand-written `@font-face` block.
+Fontsource is the source of the bytes, not a runtime import: nothing resolves
+its CSS at build time, so no hashed filename ever has to be recovered from
+Vite's manifest.
+
+Because the `@font-face` blocks are hand-written, the app **chooses the family
+names**, and names them `IBM Plex Sans` and `IBM Plex Mono` — matching the
+stacks above. Importing Fontsource's own CSS would have registered the variable
+Sans as `IBM Plex Sans Variable` and forced that name into every stack.
+
+Four files, latin subset, 89 KB total:
+
+| File | Bytes | Weights | Preloaded |
+| --- | --- | --- | --- |
+| `ibm-plex-sans-latin-wght-normal.woff2` | 45,712 | variable, 400–700 | **yes** |
+| `ibm-plex-mono-latin-600-normal.woff2` | 15,620 | 600 | **yes** |
+| `ibm-plex-mono-latin-400-normal.woff2` | 14,708 | 400 | no |
+| `ibm-plex-mono-latin-500-normal.woff2` | 14,888 | 500 | no |
+
+Mono has no variable build on Fontsource, which is why it is three files where
+Sans is one.
+
+**`font-display: optional` on all four.** A cold visit that misses the ~100 ms
+window renders entirely in the fallback for that page load, and picks up Plex
+from cache on the next one. The alternative, `swap`, was declined: it reflows
+dish names — the densest and most-read text on the phone — and Plex Sans is
+appreciably wider than the `system-ui` faces it would replace.
+
+**Preload the two weights the design cannot do without**: the variable Sans,
+which carries every dish name, and Mono 600, which is the structural weight
+behind every eyebrow, day label, course label, badge, chip and tab. Without a
+preload a font is discovered a round-trip late, after `styles.css` parses, and
+under `optional` that reliably loses the window. Preloading only Sans would
+have shipped a first visit with Plex dish names beside system-mono labels —
+the Sans/Mono split rule half-applied, which reads worse than not applied.
+Mono 400 and 500 are left to arrive on their own; they carry metadata and the
+outlined tag, where the substitution barely reads.
+
+**Cache the directory as immutable.** `optional` only pays off if the second
+visit finds the fonts already in cache and inside the window, so a
+revalidation round-trip would quietly defeat it. Stable filenames carry no
+content hash, so the policy must be declared — in **Nitro `routeRules`**, not
+`vercel.json`, whose `headers` key is ignored under the Build Output API that
+Nitro emits:
+
+```
+'/fonts/**': { headers: { 'cache-control': 'public, max-age=31536000, immutable' } }
+```
+
+The price of `immutable` on unhashed names: **upgrading IBM Plex means renaming
+the files by hand.**
 
 ### The Sans/Mono split rule
 


### PR DESCRIPTION
Resolves [What does the app look like before the fonts arrive?](https://github.com/lfeq/food-organizer/issues/67), and fills in the placeholder that [Serve IBM Plex from Google Fonts, or self-host it?](https://github.com/lfeq/food-organizer/issues/34) left behind — the Typography section has said "whether these are served from Google Fonts or self-hosted is a separate decision" ever since, even though #34 settled it.

Replaces that paragraph with a **Loading the fonts** subsection covering the whole policy.

### What it settles

- **`font-display: optional` on all four files.** No reflow, at the price of a cold visit that may render entirely in the fallback for that page load. `swap` was declined because it reflows dish names, the densest text on the phone, and Plex Sans is appreciably wider than the `system-ui` faces it replaces.
- **Preload the variable Sans and Mono 600** (61,332 of the 89 KB). Preloading Sans alone would have shipped a first visit with Plex dish names beside system-mono labels — the Sans/Mono split rule half-applied.
- **Vendor the woff2 into `public/fonts/`** under stable names with a hand-written `@font-face`, so no hashed filename has to be recovered from Vite's manifest. A consequence worth naming: because the app writes the `@font-face` itself, it also chooses the family names, so the variable Sans is `IBM Plex Sans` rather than the `IBM Plex Sans Variable` that Fontsource's own CSS would have forced into every stack.
- **`/fonts/**` cached immutable via Nitro `routeRules`** — not `vercel.json`, whose `headers` key is ignored under the Build Output API that Nitro emits. Without it, a revalidation round-trip quietly defeats `optional`.
- **Fallback stacks stay plain**, no `size-adjust` tuning: with no swap there is no reflow to smooth, and tuning would cost one `@font-face` per platform font.

### Measured, not assumed

Four files, latin subset, 89 KB total: Sans variable 45,712 B (all four weights in one file), Mono 400/500/600 at 14,708 / 14,888 / 15,620 B. Mono has no variable build on Fontsource — `@fontsource-variable/ibm-plex-mono` is a 404 — which is why it is three files where Sans is one.

Spec only; no code changes. The app currently loads no fonts at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012osHawHvq9Ur6fGMa49SMQ
