### PR TITLE
Close the type scale's weight set against the free variable axis

### DIFF
--- a/docs/design/css-structure.md
+++ b/docs/design/css-structure.md
@@ -39,7 +39,14 @@ Three constraints, all of which exist to keep the vocabulary single:
 - **No component-local redefinition.** A token is not re-bound inside a
   component or a media query. `--accent` means one thing everywhere.
 - **`tokens.css` is the only file allowed to contain a literal colour, radius,
-  or spacing value.** Everything else uses `var()`.
+  spacing value, or font weight.** Everything else uses `var()`. Weight is on
+  that list for the same reason as colour: the spec closes each family's weight
+  set deliberately (*[Weight](./visual-system.md#weight)*), and a variable Sans
+  makes `font-weight: 550` cost nothing to write and everything to unpick. The
+  four weight tokens are named by **job**, matching how colour is named by
+  role: `--weight-body`, `--weight-row`, `--weight-emphasis`, `--weight-title`
+  for `400 / 500 / 600 / 700`. Naming them by number would make the token a
+  synonym for its value and leave nothing to grep for when the ladder moves.
 
 The one value that cannot be a token is the breakpoint: CSS custom properties
 are not usable in a media query condition. See [Media queries](#media-queries).
@@ -93,7 +100,7 @@ by an `@import` manifest.
 ```
 src/styles/
   index.css          ← the manifest: @import lines and nothing else
-  tokens.css         ← :root. The only file with a literal colour/radius/space
+  tokens.css         ← :root. The only file with a literal colour/radius/space/weight
   base.css           ← reset, body, font faces, the type classes
   components/*.css   ← one file per component the spec names
   screens/*.css      ← one file per route, layout only
@@ -108,8 +115,9 @@ request. **Splitting costs nothing at runtime.**
 Two rules make "which file does this go in?" mechanical rather than a
 judgement call:
 
-1. **`tokens.css` is the only file with literal values** (restated from
-   [Tokens](#tokens), because this is where it is enforced).
+1. **`tokens.css` is the only file with literal values** — colour, radius,
+   space, or font weight (restated from [Tokens](#tokens), because this is
+   where it is enforced).
 2. **If the spec names it, it is a component file. A screen file may position
    components; it may never repaint them.** `screens/plan.css` decides where
    the short-catalogue notice sits. It does not decide what the notice looks
@@ -167,6 +175,7 @@ reviewable. Four checks cover it:
 | Check | What a hit means |
 | --- | --- |
 | A literal `#` colour outside `src/styles/tokens.css` | A token was bypassed. |
+| A `font-weight:` whose value is not a `var()` outside `tokens.css` | The closed weight set was bypassed — most likely a value invented off the free variable axis. |
 | A `@media` line that is not `min-width: 900px` | A screen invented a breakpoint. |
 | A `--` custom property declared outside `tokens.css` | A token was redefined locally, or an alias crept in. |
 | A class whose block segment does not match its file name | A component's styles are leaking into a screen file. |

--- a/docs/design/visual-system.md
+++ b/docs/design/visual-system.md
@@ -166,6 +166,9 @@ Fallback stacks: `'IBM Plex Sans', system-ui, sans-serif` and
 Google Fonts or self-hosted is a separate decision** and does not affect
 anything below.
 
+Those weight sets are **closed**, and stay closed even though Sans is a
+variable font whose axis makes extra weights free. See [Weight](#weight).
+
 ### The Sans/Mono split rule
 
 This is the single rule that makes the design feel like itself. State it as two
@@ -232,6 +235,65 @@ the week-screen direction, it overrides the split rule *on that screen only*.
 | `note` | `400 11px/1.6` | A mono paragraph — the sign-in explanation, the admin-rights block, the "added by … used 3× …" footer. |
 
 `meta` and `note` differ only in leading: `note` is for two or more lines.
+
+### Weight
+
+Both scales draw from a **closed set** of weights, and the two families are
+closed for different reasons:
+
+```
+IBM Plex Sans  400 500 600 700   closed by discipline
+IBM Plex Mono  400 500 600       closed by file cost
+```
+
+Sans is a **variable** font — one 45,712 B file carrying the continuous
+100–700 axis — so four weights and forty weights cost exactly the same. The set
+stays four anyway, because the four were never a budget. They are a ladder of
+four jobs:
+
+| Weight | Job | Roles that use it |
+| --- | --- | --- |
+| `700` | Titles | `title-page-desktop`, `title-page`, `title-sheet`. Sans only. |
+| `600` | Emphasis and controls | `dish-hero`, `dish-card`, the `button*` roles; and on the mono side `eyebrow`, `course-label`, `day-label`, `badge`, and the active state of `chip` and `tab`. |
+| `500` | Rows and inline actions | `dish-today`, `item-name`, `link-inline`, the Secondary button's label (the one component that steps `button` down a rung), mono `tag`, idle `chip`. |
+| `400` | Prose and metadata | `body`, `body-sm`, `meta-sans`, mono `meta` and `note`, idle `tab`. |
+
+**A fifth weight would need a fifth job, not a fifth number.** The axis being
+free is not a reason to spend it: a discrete set keeps seven screens
+consistent and keeps `font-weight` a token rather than a number anyone can
+invent. That discipline got *more* load-bearing, not less, when the palette's
+accessibility floor collapsed `--ink-muted` onto `--ink-secondary` — a label
+now reads as a label through family, case, size and weight, and weight is the
+only one of the four that a careless component can change by accident.
+
+**No in-between values, and no optical compensation by size.** The tempting
+use of a free axis is to render small text a little heavier — Sans `600` at
+`button-sm`'s 11px is thinner on the page than the same `600` at
+`dish-hero`'s 21px. Declined: making weight a function of size means `600`
+stops meaning one thing, and every component that changes size across the
+900px breakpoint would silently change weight with it. If a small control
+reads thin, move it up the ladder in the scale table, where the change is
+visible, rather than bending the value underneath it.
+
+The `600`/`700` gap, subtle on IBM Plex Sans at small sizes, needs no
+in-between value either: `700` runs only at 16–26px and only on titles, `600`
+at 11–21px, so the two never meet at the same size and the gap is never put to
+a side-by-side test.
+
+**The asymmetry is a constraint, not an oversight.** No variable IBM Plex Mono
+exists on either source, so Mono's three weights are three static files
+(~89 KB together) and a fourth costs both a file and a preload decision.
+Neither family may gain a weight without the other being checked: a split rule
+that applies to only one half of the system reads worse than one not applied
+at all — the same reasoning that preloads Mono `600` alongside the variable
+Sans rather than Sans alone.
+
+**Weight does not animate.** A variable font can interpolate `font-weight`
+continuously, which would let the two state changes that move weight — `tab`
+idle `400` → active `600`, `chip` idle `500` → `600` — transition rather than
+snap. Both are **Mono**, the family that cannot interpolate, so the one place
+this would apply is the one place the font forbids it. Weight changes are
+instant everywhere.
 
 ### Letter-spacing
 


### PR DESCRIPTION
Resolves #73 (map #31).

The scale fixed four Sans weights under the assumption that each weight is a separate font file. #34 removed that assumption — IBM Plex Sans ships as one 45,712 B variable file carrying the whole 100–700 axis — so the constraint that shaped the set is gone and the set needed re-deciding rather than inheriting.

**The four stay four.** They are a ladder of four jobs, not a budget:

| Weight | Job |
| --- | --- |
| `700` | Titles |
| `600` | Emphasis and controls |
| `500` | Rows and inline actions |
| `400` | Prose and metadata |

A fifth weight would need a fifth job, not a fifth number. The discipline also got *more* load-bearing since the ticket was written: #63 collapsed `--ink-muted` onto `--ink-secondary`, so a label now reads as a label through family, case, size and weight — and weight is the only one of the four a careless component can change by accident.

**Three things the free axis does not buy**, all recorded in a new `### Weight` section:

- **No in-between values, and no optical compensation by size.** Rendering small text heavier off the axis makes `600` stop meaning one thing, and every component that changes size across the 900px breakpoint would silently change weight with it. Fix a thin control by moving it up the ladder in the scale table, where it is visible.
- **The `600`/`700` gap needs no in-between value.** `700` runs only at 16–26px and only on titles, `600` at 11–21px: the two never meet at the same size, so the gap is never put to a side-by-side test.
- **Weight does not animate.** The two state changes that move weight (`tab` idle `400` → active `600`, `chip` idle `500` → `600`) are both **Mono**, the family that cannot interpolate. The one place this would apply is the one place the font forbids it.

**The Sans/Mono asymmetry is now a stated rule.** Sans is closed by discipline, Mono by file cost — no variable Plex Mono exists on either source, so its three weights are three static files (~89 KB) and a fourth costs a file *and* a preload decision. Neither family gains a weight without the other being checked: the same reasoning #67 used to preload Mono `600` alongside Sans rather than Sans alone.

**The codebase rule** (the part #64 inherits): `tokens.css` becomes the only file allowed a literal colour, radius, space **or font weight**, with the four named by **job** (`--weight-body/row/emphasis/title`) rather than by number, plus a greppable audit check for a bare `font-weight:`. Naming by number would make the token a synonym for its value and leave nothing to grep for when the ladder moves.

**Based on `worktree-wayfinder-64-css-structure` (#78), not `main`**, because `docs/design/css-structure.md` exists only there.

One correction to the spec found on the way: the ladder table caught that the **Secondary button** overrides `button` to weight `500`, the one component that steps down a rung — so the `600` row does not claim every button.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiSAQYPgNg17Xs3Ko7CoUJ