### PR TITLE
Bind elapsed-day immutability to generating, in the glossary and the spec

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -78,7 +78,13 @@ on; past weeks are kept as history.
 
 A week with no weekly plan is simply a week nobody has generated: there is no
 such thing as an empty or half-filled plan. A weekly plan comes into existence
-complete, with all seven days and all twenty-one slots, or not at all.
+complete — every [plan day](#plan-day) it holds carries all three
+[slots](#slot) — or not at all.
+
+A plan generated before its week begins holds all seven days. One generated
+once the week is already underway holds only the days still ahead: a plan day
+for a date nobody planned does not exist, so a weekly plan may hold fewer than
+seven days. What it can never hold is a day with nothing in it.
 
 A weekly plan is a record of what was decided, not a live view of the
 catalogue: once generated it holds its own copy of what came out, so deleting a
@@ -102,15 +108,19 @@ same seven days in the same order.
 
 _(Spanish UI: "día del plan")_
 
-One of the seven days of a [weekly plan](#weekly-plan), beginning at the
-instance's [week start](#week-start). Holds three [slots](#slot), one per
-[course](#course).
+One day of a [weekly plan](#weekly-plan), falling on the instance's
+[week start](#week-start) or within the six days that follow it. Holds three
+[slots](#slot), one per [course](#course).
 
 A plan day whose date has passed is **elapsed**, and an elapsed plan day is
 immutable: it can no longer be [regenerated](#regenerating). A weekly plan is a
 record of what was decided, so redrawing a day the household has already eaten
 would rewrite the past rather than change a plan. Elapsed days stay part of the
 week and stay readable; they simply stop being decisions still open.
+
+Immutability is a property of the plan day, not of the screen it is drawn on: a
+request to redraw an elapsed day is refused however it arrives, and hiding the
+control is a courtesy on top of that refusal rather than the rule itself.
 
 ## Slot
 
@@ -143,6 +153,14 @@ plan can be in.
 Generating a week that already has a plan replaces it, and the household is
 told so before it happens. The replacement is the same plan for the same week,
 not a second one: the one-plan-per-week rule holds.
+
+What it replaces is only the days still ahead. An elapsed [plan day](#plan-day)
+is immutable, so generating leaves it exactly as it stands and redraws the rest
+of the week around it. The dishes those days hold still count as used: the
+no-repeat promise is made about the whole week the household is looking at, not
+only the part that was redrawn. That leaves fewer unused dishes to draw from as
+the week wears on, so a course comfortably above seven on the week start can
+still produce a [repeating week](#repeating-week) later on.
 
 ## Regenerating
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -478,9 +478,14 @@ everyone sees the same seven days in the same order regardless of UI language.
 
 - **Current and next week only.** Both are fully generable and regenerable.
 - **Earlier weeks are read-only history.** Nothing rewrites them.
-- **Elapsed days of the current week are not locked.** Only past *weeks* freeze.
-  Wednesday's reroll still works on Friday — day-level locking would put a clock
-  in the domain for no benefit to a household.
+- **Elapsed days are locked.** A plan day whose date has passed is immutable, so
+  Wednesday's reroll no longer works on Friday. A weekly plan is a record of what
+  was decided: redrawing a day the household has already eaten rewrites the past
+  rather than changing a plan.
+- **The lock is enforced server-side**, in the same handlers that re-derive the
+  current week below, refusing with `DAY_ELAPSED`. Hiding the control is a
+  courtesy on top of that refusal, not the rule: the client's notion of "today"
+  is baked into a render and goes stale in a tab left open overnight.
 - The week picker's range is capped accordingly: the sidebar offers **This week**
   and **Next week**, and history is read-only.
 
@@ -647,9 +652,9 @@ change-password screen and logout.
 
 ### 9.1 Generating a week
 
-Draw one dish per course per day: three independent draws of seven,
-**without replacement within the course**, so generating never repeats a dish
-within the week as long as that course holds at least seven dishes.
+Draw one dish per course per day: three independent draws, one per day being
+written, **without replacement within the course**, so generating never repeats
+a dish within the week as long as that course holds at least seven dishes.
 
 - **Generating has no memory.** What came out last week does not influence this
   week.
@@ -661,9 +666,23 @@ within the week as long as that course holds at least seven dishes.
 - **A course below seven repeats as needed** — there are not enough dishes to go
   round. This is announced by the banner in §9.3, not refused.
 - **Generating over an existing plan is offered behind an explicit
-  confirmation** stating the current plan is replaced. It overwrites **in
-  place**: no version history, no second plan for that week.
-- The plan, its seven `plan_day` rows and its twenty-one `slot` rows are written
+  confirmation**: "The days still ahead will be redrawn from the catalogue. This
+  cannot be undone." It overwrites **in place**: no version history, no second
+  plan for that week.
+- **Generating redraws only the days still ahead.** Elapsed plan days are
+  immutable (§6.2), so they are left exactly as they stand and the rest of the
+  week is redrawn around them.
+- **Elapsed days' dishes count as used.** The redraw excludes the names they
+  hold, so the no-repeat promise covers the whole week the household is looking
+  at, not just the part that was redrawn. This shrinks the pool as the week wears
+  on, so a course comfortably above seven on the week start can still produce a
+  repeating week (§9.3) later in the week.
+- **Generating a week already underway that has no plan writes only the days
+  still ahead.** It does not invent the days that have passed: those would be
+  elapsed, and therefore immutable, the instant they were written — a permanent
+  record of meals nobody decided. **A weekly plan may therefore hold fewer than
+  seven `plan_day` rows.** What it can never hold is a day with nothing in it.
+- The plan, its `plan_day` rows and the three `slot` rows of each are written
   **in one transaction** — required by constraint trigger 3 and by "complete or
   not at all".
 
@@ -685,6 +704,10 @@ There is no separate "pool" that regenerating draws down. **Each regeneration
 recomputes against the week as it currently stands**, so repeated regenerations
 cannot drift into duplicates.
 
+**An elapsed day refuses outright** with `DAY_ELAPSED` (§6.2), before any of
+this. The screen names the reason rather than offering a retry, and refreshes
+itself so the control disappears — a retry can only fail again.
+
 **When the candidate set is empty, it falls back to the whole course**,
 excluding only the dish being replaced — it does **not** refuse. Refusing would
 make the app's most-used control dead on arrival on a small catalogue. Swapping
@@ -694,7 +717,8 @@ reroll's contract is **"this slot changes, nothing else does"**.
 
 So **regenerating may repeat**, and the app says so — §9.3.
 
-The candidate count is exactly `dishes_in_course − 7`, which is why the seed
+The candidate count is exactly `dishes_in_course − 7` for a full seven-day week
+(and `dishes_in_course − plan_days` for a short one, §9.1), which is why the seed
 catalogue is nine and not seven:
 
 | Per course | Generating | Regenerating |
@@ -836,15 +860,18 @@ Two columns.
 
 - **Today is a large card on the left**, showing all three courses at reading
   size, with its own labelled reroll button.
-- **The other six days are compact cards** stacked in a narrower right-hand
+- **The week's remaining days are compact cards** stacked in a narrower right-hand
   column, one line per course, each with a `↻` control.
 
 Today is distinguished three ways at once — its own column, a green outline, and
 a `today` tag — because the app's single most common use is answering "what are
 we eating today" at a glance.
 
-**Days already elapsed are dimmed but not locked**: past *weeks* freeze, elapsed
-days do not, so they keep their reroll control (§6.2).
+**Days already elapsed are dimmed and read-only**: they lose their reroll
+control entirely rather than showing a disabled one (§6.2). They stay part of
+the week and stay readable; they simply stop being decisions still open. Where a
+week was generated mid-week, the days before it was generated have no cards at
+all — no placeholder rows.
 
 When the week has no plan, the screen offers **Generate**; when it has one and
 the week is writable, generating again is offered behind the confirmation in


### PR DESCRIPTION
Documents the decision on **Where is elapsed-day immutability enforced?** (#72), part of **Map: Pleasant on the phone, comfortable on the desktop** (#31). Docs only — no code.

## `CONTEXT.md` (commit 1)

Resolving #72 settled that elapsed-day immutability is a property of the plan day rather than of the screen. That exposed a contradiction already sitting in the glossary: `## Regenerating` says only a day still ahead can be redrawn, while `## Generating` says generating a week that already has a plan replaces it — which on a Thursday means one tap rewrites three days the household has already eaten.

- **`## Generating`** — generating a week already underway redraws only the days still ahead. Elapsed days are left exactly as they stand, and the dishes they hold still count as used, so *never repeats a dish within the week* stays a promise about the whole week rather than the redrawn part. Records the consequence: the effective pool shrinks as the week wears on, so a repeating week can now arise from a course that was comfortably above seven on the week start.
- **`## Weekly plan` / `## Plan day`** — a plan generated mid-week holds only the days still ahead, so a weekly plan may hold fewer than seven plan days. What it can never hold is a day with nothing in it, so "complete or not at all" survives, restated per plan day instead of per week.
- **`## Plan day`** — immutability belongs to the day, not the screen it is drawn on: the refusal holds however the request arrives.

## `SPEC.md` (commit 2)

Found while checking the first commit, and worth flagging on its own: **the build spec has been contradicting the glossary since #32.** PR #71 amended only `CONTEXT.md`, so SPEC.md still said §6.2 "Elapsed days of the current week are **not** locked. Only past *weeks* freeze. Wednesday's reroll still works on Friday" and §11.2 "dimmed but **not locked** … so they keep their reroll control". A builder following the spec would have built the opposite of the decision.

Four sites brought in line:

- **§6.2** — states the lock, and that it is enforced server-side alongside the existing current-week re-derivation, refusing with `DAY_ELAPSED`.
- **§9.1** — generating becomes a partial redraw of the days still ahead; elapsed days' dishes count as used; a mid-week generate with no existing plan writes only the days still ahead; the transaction bullet no longer hard-codes seven `plan_day` and twenty-one `slot` rows; confirmation copy updated.
- **§9.2** — an elapsed day refuses outright, before the candidate-set logic; the candidate-count formula gains the short-week case.
- **§11.2** — elapsed days are dimmed and read-only, losing the reroll control rather than showing a disabled one; never-planned dates get no cards at all.

The code changes themselves (the `DAY_ELAPSED` code, the day-level check in `rerollDay`, the partial redraw in `generateWeek`, the `i18n.ts` keys) are handed off in the resolution comment on #72.